### PR TITLE
Change packet_index functions to more closely match RFC

### DIFF
--- a/kernel-module/xt_RTPENGINE.c
+++ b/kernel-module/xt_RTPENGINE.c
@@ -1901,7 +1901,7 @@ static u_int64_t packet_index(struct re_crypto_context *c,
 	if (unlikely(!s->last_index))
 		s->last_index = seq;
 
-  /* rfc 3711 appendix A, modified, and sections 3.3 and 3.3.1 */
+	/* rfc 3711 appendix A, modified, and sections 3.3 and 3.3.1 */
 	s_l = (s->last_index & 0x00000000ffffULL);
 	roc = (s->last_index & 0xffffffff0000ULL) >> 16;
 	v = 0;

--- a/kernel-module/xt_RTPENGINE.c
+++ b/kernel-module/xt_RTPENGINE.c
@@ -1888,8 +1888,10 @@ static u_int64_t packet_index(struct re_crypto_context *c,
 {
 	u_int16_t seq;
 	u_int64_t index;
-	long long int diff;
 	unsigned long flags;
+	u_int16_t s_l;
+	u_int32_t roc;
+	u_int32_t v;
 
 	seq = ntohs(rtp->seq_num);
 
@@ -1899,24 +1901,26 @@ static u_int64_t packet_index(struct re_crypto_context *c,
 	if (unlikely(!s->last_index))
 		s->last_index = seq;
 
-	/* rfc 3711 appendix A, modified, and sections 3.3 and 3.3.1 */
-	index = ((u_int64_t) c->roc << 16) | seq;
-	diff = index - s->last_index;
-	if (diff >= 0) {
-		if (diff < 0x8000)
-			s->last_index = index;
-		else if (index >= 0x10000)
-			index -= 0x10000;
+  /* rfc 3711 appendix A, modified, and sections 3.3 and 3.3.1 */
+	s_l = (s->last_index & 0x00000000ffffULL);
+	roc = (s->last_index & 0xffffffff0000ULL) >> 16;
+	v = 0;
+
+	if (s_l < 0x8000) {
+		if (((seq - s_l) > 0x8000) && roc > 0)
+			v = (roc - 1) % 0x10000;
+		else
+			v = roc;
+	} else {
+		if ((s_l - 0x8000) > seq)
+			v = (roc + 1) % 0x10000;
+		else
+			v = roc;
 	}
-	else {
-		if (diff >= -0x8000)
-			;
-		else {
-			index += 0x10000;
-			c->roc++;
-			s->last_index = index;
-		}
-	}
+
+	index = (v << 16) | seq;
+	s->last_index = index;
+	c->roc = v;
 
 	spin_unlock_irqrestore(&c->lock, flags);
 


### PR DESCRIPTION
This became necessary because of the way Asterisk handles Sequence
numbers when changing SSRC.  They continue to increment a single
sequence number even though the SSRC is different, on switching back
this causes the packet_index function to interpret this as many lost
packets.  The previous function had dead-spots that would not adjust
the packet_index at all if the difference fell in these ranges.  These
gaps always resulted in behavior contra what would happen in webrtc
clients.
